### PR TITLE
Compile without AVX

### DIFF
--- a/include/simd_aux.h
+++ b/include/simd_aux.h
@@ -31,7 +31,7 @@
 /**
  * @brief For clean code of fast multiple add
  */
-#ifdef NO_SIMD
+#ifdef NO_RQRMI_OPT
 	#define FMA(a,b,c) 				\
 		a = (a*b)+c;
 #elif __AVX512F__
@@ -53,7 +53,7 @@
 /**
  * @brief General defines that change according to available SIMD engine
  */
-#ifdef NO_SIMD
+#ifdef NO_RQRMI_OPT
 #	define SIMD_WIDTH 1
 #	define PS_REG float
 #	define EPU_REG unsigned int

--- a/src/rqrmi_fast.cpp
+++ b/src/rqrmi_fast.cpp
@@ -121,7 +121,7 @@ void RQRMIFast::evaluate(wide_scalar_t& inputs, wide_scalar_t& status, wide_scal
 	// Next index of submodel in stage, per input
 	wide_scalar_t next_idx;
 	// A collection of submodels
-	submodel_collection_t submodels;
+	submodel_collection_t submodels {};
 
 	// Holds a vector of submodels input normalization factors
 	wide_scalar_t input_mean, input_stddev;

--- a/src/simd_aux.cpp
+++ b/src/simd_aux.cpp
@@ -28,9 +28,11 @@
  * @brief Returns a string representation of single-precision float vector
  */
 std::string simd_ps_vector_logger(PS_REG v) {
+#ifndef NO_RQRMI_OPT
 	union {float f; int i;} fp;
+#endif
 	std::stringstream ss;
-#ifdef NO_SIMD
+#ifdef NO_RQRMI_OPT
 	ss<<"["<<v<<"]";
 #elif __AVX512F__
 	float f0,f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f13,f14,f15;
@@ -80,9 +82,11 @@ std::string simd_ps_vector_logger(PS_REG v) {
  * @brief Returns a string representation of unsigned int vector
  */
 std::string simd_epu_vector_logger(EPU_REG v) {
+#ifndef NO_RQRMI_OPT
 	union {unsigned int f; int i;} fp;
+#endif
 	std::stringstream ss;
-#ifdef NO_SIMD
+#ifdef NO_RQRMI_OPT
 	ss<<"["<<v<<"]";
 #elif __AVX512F__
 	unsigned int f0,f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f13,f14,f15;


### PR DESCRIPTION
- Replaced `#ifdef NO_SIMD` with `#ifdef NO_RQRMI_OPT`
- Implemented interval set validation without SIMD

After compiling, I ran without `--trace-silent` to verify that packets are not misclassified.